### PR TITLE
Fix: Ensure `$time` is set from `innertext` when `datetime` attribute is not found

### DIFF
--- a/bridges/CssSelectorComplexBridge.php
+++ b/bridges/CssSelectorComplexBridge.php
@@ -442,7 +442,7 @@ class CssSelectorComplexBridge extends BridgeAbstract
         if (!is_null($time_selector) && $time_selector != '') {
             $time_element = $entry_html->find($time_selector, 0);
             $time = $time_element->getAttribute('datetime');
-            if (is_null($time)) {
+            if (empty($time)) {
                 $time = $time_element->innertext;
             }
 


### PR DESCRIPTION
This patch addresses an issue where the $time variable is not correctly assigned from the innertext of the $time_element when the datetime attribute is missing.